### PR TITLE
Replace deprecated org.codehaus.groovy.grails classes

### DIFF
--- a/grails-app/controllers/org/grails/plugins/smartclient/SmartClientDatasourceController.groovy
+++ b/grails-app/controllers/org/grails/plugins/smartclient/SmartClientDatasourceController.groovy
@@ -1,7 +1,7 @@
 package org.grails.plugins.smartclient
 
 import grails.converters.JSON
-import org.codehaus.groovy.grails.commons.GrailsClassUtils
+import grails.util.GrailsClassUtils
 
 
 /**


### PR DESCRIPTION
Necessary to work with grails 3.2